### PR TITLE
Add a `run_test` script. Fix issue 20.

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Delete generated file if they exists.
+if [ -f movie_gen.go ]; then
+	rm movie_gen.go
+fi
+
+# Build `gen` binary according to current source,
+# regenerate the `Movie` struct and remove
+# the binary.
+go build -o test_gen ..
+./test_gen -f *models.Movie # Need to force, otherwise movie_test.go doesn't compile and blocks `gen`
+rm test_gen
+
+# Run the test with the updated `Movies` struct.
+go test .


### PR DESCRIPTION
This script compiles a fresh `gen` binary from the current source, regenerate `movie_gen.go` and runs the tests on that file.  It leaves the generated file there for following inspection, but removes the `gen` binary.
