### PR TITLE
Added predicate and predicate operations

### DIFF
--- a/typewriters/genwriter/genwriter.go
+++ b/typewriters/genwriter/genwriter.go
@@ -42,6 +42,11 @@ func (m model) Plural() (result string) {
 	return
 }
 
+func (m model) Predicate() (result string) {
+	result = m.Name + "Predicate"
+	return
+}
+
 // genwriter prepares models for later use in the .Validate() method. It must be called prior.
 func (g GenWriter) ensureValidation(t typewriter.Type) error {
 	if !g.validated[t.String()] {
@@ -215,6 +220,11 @@ func (g GenWriter) Write(w io.Writer, t typewriter.Type) {
 	}
 
 	tmpl, _ := standardTemplates.Get("plural")
+	if err := tmpl.Execute(w, m); err != nil {
+		panic(err)
+	}
+
+	tmpl, _ = standardTemplates.Get("predicates")
 	if err := tmpl.Execute(w, m); err != nil {
 		panic(err)
 	}

--- a/typewriters/genwriter/templates.go
+++ b/typewriters/genwriter/templates.go
@@ -12,6 +12,33 @@ type {{.Plural}} []{{.Pointer}}{{.Name}}
 `,
 	},
 
+	"predicates": &typewriter.Template{
+		Text: `// {{.Predicate}} is a function that accepts a {{.Pointer}}{{.Name}} and returns a bool.  Used with gen methods below. Use this type where you would use func({{.Pointer}}{{.Name}}) bool.
+type {{.Predicate}} func(item {{.Pointer}}{{.Name}}) bool
+
+// And combines two predicates into a new predicate that is satisfied if both of the original predicates are satisfied
+func (rcv {{.Predicate}}) And(other {{.Predicate}}) {{.Predicate}} {
+	return func (item {{.Pointer}}{{.Name}}) bool {
+		return rcv(item) && other(item)
+	}
+}
+
+// Or combines two predicates into a new predicate that is satisfied if either of the original predicates is satisfied
+func (rcv {{.Predicate}}) Or(other {{.Predicate}}) {{.Predicate}} {
+	return func (item {{.Pointer}}{{.Name}}) bool {
+		return rcv(item)|| other(item)
+	}
+}
+
+// Not inverts a predicate that is satisfied if the original predicates is not satisfied
+func (rcv {{.Predicate}}) Not() {{.Predicate}} {
+	return func (item {{.Pointer}}{{.Name}}) bool {
+		return !rcv(item)
+	}
+}
+`,
+	},
+
 	"All": &typewriter.Template{
 		Text: `
 // All verifies that all elements of {{.Plural}} return true for the passed func. See: http://clipperhouse.github.io/gen/#All

--- a/typewriters/genwriter/test/other_gen.go
+++ b/typewriters/genwriter/test/other_gen.go
@@ -12,6 +12,30 @@ import (
 // Others is a slice of type Other, for use with gen methods below. Use this type where you would use []Other. (This is required because slices cannot be method receivers.)
 type Others []Other
 
+// OtherPredicate is a function that accepts a Other and returns a bool.  Used with gen methods below. Use this type where you would use func(Other) bool.
+type OtherPredicate func(item Other) bool
+
+// And combines two predicates into a new predicate that is satisfied if both of the original predicates are satisfied
+func (rcv OtherPredicate) And(other OtherPredicate) OtherPredicate {
+	return func(item Other) bool {
+		return rcv(item) && other(item)
+	}
+}
+
+// Or combines two predicates into a new predicate that is satisfied if either of the original predicates is satisfied
+func (rcv OtherPredicate) Or(other OtherPredicate) OtherPredicate {
+	return func(item Other) bool {
+		return rcv(item) || other(item)
+	}
+}
+
+// Not inverts a predicate that is satisfied if the original predicates is not satisfied
+func (rcv OtherPredicate) Not() OtherPredicate {
+	return func(item Other) bool {
+		return !rcv(item)
+	}
+}
+
 // Max returns the maximum value of Others. In the case of multiple items being equally maximal, the first such element is returned. Returns error if no elements. See: http://clipperhouse.github.io/gen/#Max
 func (rcv Others) Max() (result Other, err error) {
 	l := len(rcv)

--- a/typewriters/genwriter/test/thing_gen.go
+++ b/typewriters/genwriter/test/thing_gen.go
@@ -16,6 +16,30 @@ import (
 // Things is a slice of type Thing, for use with gen methods below. Use this type where you would use []Thing. (This is required because slices cannot be method receivers.)
 type Things []Thing
 
+// ThingPredicate is a function that accepts a Thing and returns a bool.  Used with gen methods below. Use this type where you would use func(Thing) bool.
+type ThingPredicate func(item Thing) bool
+
+// And combines two predicates into a new predicate that is satisfied if both of the original predicates are satisfied
+func (rcv ThingPredicate) And(other ThingPredicate) ThingPredicate {
+	return func(item Thing) bool {
+		return rcv(item) && other(item)
+	}
+}
+
+// Or combines two predicates into a new predicate that is satisfied if either of the original predicates is satisfied
+func (rcv ThingPredicate) Or(other ThingPredicate) ThingPredicate {
+	return func(item Thing) bool {
+		return rcv(item) || other(item)
+	}
+}
+
+// Not inverts a predicate that is satisfied if the original predicates is not satisfied
+func (rcv ThingPredicate) Not() ThingPredicate {
+	return func(item Thing) bool {
+		return !rcv(item)
+	}
+}
+
 // All verifies that all elements of Things return true for the passed func. See: http://clipperhouse.github.io/gen/#All
 func (rcv Things) All(fn func(Thing) bool) bool {
 	for _, v := range rcv {

--- a/typewriters/genwriter/test/things_test.go
+++ b/typewriters/genwriter/test/things_test.go
@@ -4,6 +4,67 @@ import (
 	"testing"
 )
 
+func TestAnd(t *testing.T) {
+	True := ThingPredicate(func(x Thing) bool { return true })
+	False := ThingPredicate(func(x Thing) bool { return false })
+
+	ff := False.And(False)
+	ft := False.And(True)
+	tt := True.And(True)
+	tf := True.And(False)
+
+	if ff(zero) {
+		t.Errorf("And FF should not be true")
+	}
+	if ft(zero) {
+		t.Errorf("And FT should not be true")
+	}
+	if !tt(zero) {
+		t.Errorf("And TT should be true")
+	}
+	if tf(zero) {
+		t.Errorf("And TF should not be true")
+	}
+}
+
+func TestOr(t *testing.T) {
+	True := ThingPredicate(func(x Thing) bool { return true })
+	False := ThingPredicate(func(x Thing) bool { return false })
+
+	ff := False.Or(False)
+	ft := False.Or(True)
+	tt := True.Or(True)
+	tf := True.Or(False)
+
+	if ff(zero) {
+		t.Errorf("Or FF should not be true")
+	}
+	if !ft(zero) {
+		t.Errorf("Or FT should be true")
+	}
+	if !tt(zero) {
+		t.Errorf("Or TT should be true")
+	}
+	if !tf(zero) {
+		t.Errorf("Or TF should be true")
+	}
+}
+
+func TestNot(t *testing.T) {
+	True := ThingPredicate(func(x Thing) bool { return true })
+	False := ThingPredicate(func(x Thing) bool { return false })
+
+	expectFalse := True.Not()
+	expectTrue := False.Not()
+
+	if expectFalse(zero) {
+		t.Errorf("Not True should not be true")
+	}
+	if !expectTrue(zero) {
+		t.Errorf("Not False should be true")
+	}
+}
+
 func TestAll(t *testing.T) {
 	all1 := things.All(func(x Thing) bool {
 		return x.Name == "First"


### PR DESCRIPTION
- Added a type definition for a predicate which takes the item being generated and defines a TypePredicate func(item Type) bool
- Added member functions on the predicate for And, Or, and Not

I was hand rolling something like what gen makes automatically for a project I was recently working on.  By treating the predicate functions as a defined type and defining the And,Or, etc. I was able to produce some very clean looking code:

``` go
        if !member.Claims.Any(YearsWindowSelector(endMonth, 1).And(acoEncounter)) {
            return *NewRuleResultClinicallyExcluded(ExNoEncounter)
        }
        if member.Claims.Any(YearsWindowSelector(endMonth, 2).And(examPerformed)) {
            return *NewRuleResultIndicated(1)
        }

```

Here, YearsWindowSelector() is a function that returns a predicate that filters claims by date.  acoEncounter and examPerformed are predicates that are looking at the services rendered for a given claim.

The syntax for Not() is a bit clunky; unfortunately since there's no overloading, the receiver is the only way to differentiate the different predicate methods.

Logistics:
- I wrote tests for 'thing', but not 'other' (they would pretty much be the same).  I can add those if you like.
- I did not make the predicate stuff optional.  I will take a stab at that if you are otherwise willing to pull this in.
- Locally, I had to change gen/typewriters/genwriter/test/setup.go to reference biggernoise/gen and not clipperhouse/gen.  I don't think that you will need (or want) that change if you're evaluating this P/R
- If you accept this, it would probably make sense to change the templates for the other methods so they take predicates.  I did not do that with this P/R to avoid gunking it up.  I would be happy to do so if you want to pull this in.

Hope that this can make it into your library.
