### PR TITLE
Unknown subcommands print usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,10 +24,12 @@ func main() {
 			tail = args[2:]
 		}
 		err = get(tail)
-	case "help":
-		err = help()
 	case "list":
 		err = list()
+	case "help":
+		fallthrough
+	default:
+		err = help()
 	}
 
 	if err != nil {


### PR DESCRIPTION
If you use a subcommand that doesn't exist, it should print usage.

I left `case "help":` for clarity, and just in case unknown subcommands have different behavior in the future (like saying "invalid subcommand" or something).
