### PR TITLE
Print gen errors instead of discarding

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,12 +5,19 @@ import "os"
 func main() {
 	var err error
 
+	defer func() {
+		if err != nil {
+			os.Stderr.WriteString(err.Error() + "\n")
+			os.Exit(1)
+		}
+	}()
+
 	args := os.Args
 
 	if len(args) == 1 {
 		// simply typed 'gen'; run is the default command
 		err = run()
-		return
+		return // see defer
 	}
 
 	cmd := args[1]
@@ -29,9 +36,5 @@ func main() {
 	case "list":
 		err = list()
 	}
-
-	if err != nil {
-		os.Stderr.WriteString(err.Error() + "\n")
-		os.Exit(1)
-	}
+	return // see defer
 }


### PR DESCRIPTION
Previously if `run()` returned an error, it was discarded by returning immediately instead of being printed out. This fixes it by deferring the error printing so errors are still printed when returning prematurely.

Another way of fixing this would be to put the switch in an else of the `len(args) == 1` if statement and removing the early return. Let me know if that's what you'd prefer and I'll amend the pull request.
