### PR TITLE
Don't require complete typecheck; allows regen

### DIFF
--- a/typewriter/parser.go
+++ b/typewriter/parser.go
@@ -48,10 +48,11 @@ func getTypes(directive string, filter func(os.FileInfo) bool) ([]Type, error) {
 			return typs, astErr
 		}
 
-		typesPkg, typesErr := types.Check(name, fset, astFiles)
+		conf := types.Config{}
+		typesPkg, typesErr := conf.Check(name, fset, astFiles, nil)
 
 		if typesErr != nil {
-			return typs, typesErr
+			fmt.Println("typecheck error:", typesErr, "\nattempting to continue...")
 		}
 
 		pkg := &Package{typesPkg}


### PR DESCRIPTION
This allows gen to generate code that is already being used in the original program. This is a first step towards fully automated partial generation as discussed in #46.

For example, gen can now create `things_gen.go` from this directly, *without* first commenting out the contents of `main`:
```go
// thing.go
package main
// +gen
type Thing int
func main() {
	t := Things{2,1,3}
	x, _ := t.Min()
	println(x)
}
```

Output:
```
>gen
typecheck error: thing.go:6:7: undeclared name: Things
attempting to continue...
  Writing thing_gen.go
>go build
>
```

The previous code called `types.Check`, which [calls `types.Config.Check`][1] and explicitly returns a `nil` Package on any error. This change calls `types.Config.Check` directly which will return a partial result if possible. If there is an error, instead of completely bailing out, it still attempts to generate the templates. This should succeed as long as the type itself can be evaluated.

That a typecheck error was detected is still printed out just in case the error is unrelated to gen and the user should take action on it. This may not be necessary, and doesn't allow code that calls `getTypes` to handle it explicitly (instead of being printed out).

[1]: https://code.google.com/p/go/source/browse/go/types/api.go?repo=tools#40