### PR TITLE
[POC] Prune Unused Methods in Default Mode

### DIFF
--- a/typewriter/package.go
+++ b/typewriter/package.go
@@ -1,17 +1,23 @@
 package typewriter
 
 import (
+	"go/ast"
+	"go/token"
+
 	_ "code.google.com/p/go.tools/go/gcimporter"
 	"code.google.com/p/go.tools/go/types"
 )
 
 type Package struct {
 	*types.Package
+	fset       *token.FileSet
+	astPackage *ast.Package
+	info       *types.Info
 }
 
 func NewPackage(path, name string) *Package {
 	return &Package{
-		types.NewPackage(path, name),
+		Package: types.NewPackage(path, name),
 	}
 }
 
@@ -31,4 +37,50 @@ func (p *Package) Eval(name string) (result Type, err error) {
 		Type:       t,
 	}
 	return
+}
+
+func (pkg *Package) GetSelectorsOn(search types.Type) []string {
+	data := walkerData{pkg.Package, pkg.fset, search, pkg.info.Scopes, make(map[string]struct{})}
+	ast.Walk(walker{pkg.Package.Scope(), &data}, pkg.astPackage)
+
+	selectors := make([]string, 0)
+	for k := range data.selectors {
+		selectors = append(selectors, k)
+	}
+	return selectors
+}
+
+type walkerData struct {
+	typesPkg  *types.Package
+	fset      *token.FileSet
+	search    types.Type
+	scopes    map[ast.Node]*types.Scope
+	selectors map[string]struct{}
+}
+
+type walker struct {
+	scope *types.Scope
+	data  *walkerData
+}
+
+func (w walker) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return w
+	}
+	d := w.data
+	if newscope, ok := d.scopes[node]; ok {
+		return walker{newscope, d}
+	}
+	switch n := node.(type) {
+	case *ast.FuncDecl:
+		newscope := d.scopes[n.Type]
+		return walker{newscope, d}
+	case *ast.SelectorExpr:
+		ident := n.Sel.Name
+		typ, _, err := types.EvalNode(d.fset, n.X, d.typesPkg, w.scope)
+		if err == nil && types.Identical(typ, d.search) {
+			d.selectors[ident] = struct{}{}
+		}
+	}
+	return w
 }

--- a/typewriter/parser.go
+++ b/typewriter/parser.go
@@ -48,10 +48,11 @@ func getTypes(directive string, filter func(os.FileInfo) bool) ([]Type, error) {
 			return typs, astErr
 		}
 
-		typesPkg, typesErr := types.Check(name, fset, astFiles)
+		conf := types.Config{}
+		typesPkg, typesErr := conf.Check(name, fset, astFiles, nil)
 
 		if typesErr != nil {
-			return typs, typesErr
+			fmt.Println("typecheck error:", typesErr, "\nattempting to continue...")
 		}
 
 		pkg := &Package{typesPkg}

--- a/typewriter/parser.go
+++ b/typewriter/parser.go
@@ -49,13 +49,14 @@ func getTypes(directive string, filter func(os.FileInfo) bool) ([]Type, error) {
 		}
 
 		conf := types.Config{}
-		typesPkg, typesErr := conf.Check(name, fset, astFiles, nil)
+		info := &types.Info{Scopes: make(map[ast.Node]*types.Scope)}
+		typesPkg, typesErr := conf.Check(name, fset, astFiles, info)
 
 		if typesErr != nil {
 			fmt.Println("typecheck error:", typesErr, "\nattempting to continue...")
 		}
 
-		pkg := &Package{typesPkg}
+		pkg := &Package{typesPkg, fset, astPackage, info}
 
 		for _, decl := range decls {
 			if decl.Lparen == 0 {

--- a/typewriters/genwriter/genwriter.go
+++ b/typewriters/genwriter/genwriter.go
@@ -35,9 +35,13 @@ type model struct {
 	projections []Projection
 }
 
-func (m model) Plural() (result string) {
-	result = inflect.Pluralize(m.Name)
-	if result == m.Name {
+func (m model) Plural() string {
+	return plural(m.Type.Name)
+}
+
+func plural(name string) (result string) {
+	result = inflect.Pluralize(name)
+	if result == name {
 		result += "s"
 	}
 	return

--- a/typewriters/genwriter/methods.go
+++ b/typewriters/genwriter/methods.go
@@ -31,12 +31,19 @@ func evaluateTags(t typewriter.Type) (standardMethods, projectionMethods []strin
 
 	nilProjections = !found
 
-	if nilMethods || methods.Negated {
-		// default to all
+	if methods.Negated {
 		standardMethods = standardTemplates.GetAllKeys()
-		if !nilProjections {
-			projectionMethods = projectionTemplates.GetAllKeys()
+	} else if nilMethods {
+		ptype, err := t.Package.Eval(plural(t.Name))
+		if err == nil {
+			standardMethods = t.Package.GetSelectorsOn(ptype.Type)
+		} else {
+			standardMethods = standardTemplates.GetAllKeys()
 		}
+	}
+
+	if !nilProjections && (nilMethods || methods.Negated) {
+		projectionMethods = projectionTemplates.GetAllKeys()
 	}
 
 	if !nilMethods {


### PR DESCRIPTION
In default mode, (where the user just annotates the type and doesn't specify exactly which methods should be generated by using tags) only the methods that are used should be generated, and `gen` should automatically detect these instances.

Here, I demonstrate a proof-of-concept for how this could work. I apologize for the wall-o-text, there's a TL;DR at the end.

Note: This PR is a very rough Proof-Of-Concept, and I don't expect it to be merged. Specifically, the last commit (c32665f) is quite incomplete. This is based on commits from PR #64 because it has functionality that I think is necessary for gen to work on a changing codebase with this feature.

In commit f508d49 I add the method `typewriter.Package.GetSelectorsOn(types.Type)`. In the AST, selector nodes are all the dot-expressions. They have the form `x.Y` where `x` is any expression (often an identifier, but not necessarily), and `Y` is an identifier. Note that there doesn't exist a 'method-call node', instead, a method call is just a function call where the function to call is determined by the result of the selector node instead of a raw identifier. (Think `(x.Method)()` not `x(.Method())`.) It turns out we don't _want_ to consider function calls at all, just because we don't want to miss cases where the user saves the result of a selector and calls it later, like: `fn := x.Method; fn();` (which is [perfectly valid](http://play.golang.org/p/9VsK7ohp3e)).

`GetSelectorsOn` returns a `[]string` of all the unique identifiers that were selected on expressions of the same type as the passed `types.Type`. It works by walking the AST while maintaining the current `types.Scope` so the expression part of every `ast.SelectorExpr` can be evaluated to a specific type. A mapping from `ast.Node` to `types.Scope` is provided by passing a [`types.Info`](https://godoc.org/code.google.com/p/go.tools/go/types#Info) struct to the [`types.Config.Check`](https://godoc.org/code.google.com/p/go.tools/go/types#Config.Check) method. Unfortunately, this mapping contains only the scope nodes themselves so a scope hierarchy must be maintained while walking the tree. Worse, the scope node of a given node is not always an ancestor. For example, the scope of `ast.FuncDecl.Body` statements is actually under `ast.FuncDecl.FuncType`. This isn't impossible to work around, it just adds a bit of special case handling, and I haven't tested all possible scope node types for these special cases.

Also, I changed `genwriter.evaluateTags` in commit c32665f to use the new GetSelectorsOn method to prune the generated methods to only the ones that are used.

The current, _not ideal_, workflow for new projects looks like this:
1. Start writing your project files, annotate a type with `// +gen` and use the not-yet-generated plural type and methods as needed.
2. Run `gen`. Because the plural type doesn't yet exist, type checking cannot determine which selectors are called on it yet, so it generates _all methods_.
3. Run `gen` again immediately afterwards. Now that the plural exists, more detailed typechecking can occur. Now it gets a list of exactly what methods were used throughout the project, and it generates those methods.
4. You may need to run `gen` a couple more times to fully prune the project. I'm not sure why this is necessary. (I told you, rough edges :smile:)

Ideally, steps 2-4 would be collapsed down to one step where the user runs `gen` only once (which might execute itself in the background multiple times). The workflow for existing projects starts at step 2 above.

_TL;DR_: [Here's a test file](https://gist.github.com/infogulch/cb67ad61a2b06741768f) with instructions for how it would work. The current procedure is less than ideal and could be greatly improved.
